### PR TITLE
Fix WinMain annotation

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-winmain.md
+++ b/sdk-api-src/content/winbase/nf-winbase-winmain.md
@@ -62,7 +62,7 @@ Type: <b>HINSTANCE</b>
 
 A handle to the current instance of the application.
 
-### -param hPrevInstance [in]
+### -param hPrevInstance [in, optional]
 
 Type: <b>HINSTANCE</b>
 


### PR DESCRIPTION
Currently, WinMain's annotations are documented incorrectly.
`hPrevInstance` is declared as `_In_opt_` in WinBase.h, which causes IntelliSense to complain about inconsistent annotation.
![image](https://github.com/cuckydev/sdk-api/assets/44537737/ef1ac4bc-bb22-4aa7-a207-21f0e56fca87)
